### PR TITLE
fix(window): set spell false for the minimap window

### DIFF
--- a/lua/neominimap/window.lua
+++ b/lua/neominimap/window.lua
@@ -211,6 +211,7 @@ M.create_minimap_window = function(winid)
     vim.wo[mwinid].sidescrolloff = 0
     vim.wo[mwinid].winblend = 0
     vim.wo[mwinid].cursorline = true
+    vim.wo[mwinid].spell = false
 
     logger.log(string.format("Minimap window %d created for window %d", mwinid, winid), vim.log.levels.TRACE)
     return mwinid


### PR DESCRIPTION
When you have spellcheck on by default, the window has spell checking that always false fires.
![image](https://github.com/user-attachments/assets/66af9d11-af52-4100-b980-fb3923448dd9)

After we set it false implicitly:
![image](https://github.com/user-attachments/assets/1ac4daba-82a6-43df-a3d6-483551430fc0)
