### PR TITLE
fix: deal with short windows and border formats

### DIFF
--- a/lua/neominimap/config/internal.lua
+++ b/lua/neominimap/config/internal.lua
@@ -63,7 +63,7 @@ M.default_config = {
         enabled = true, ---@type boolean
     },
     z_index = 1, ---@type integer
-    window_border = "single", ---@type string | string[]
+    window_border = "single", ---@type string | string[] | [string, string][]
 
     ---@type table | fun(winid: integer) : table
     winopt = {},

--- a/lua/neominimap/window.lua
+++ b/lua/neominimap/window.lua
@@ -169,7 +169,7 @@ local get_window_config = function(winid)
     local height = (function()
         local border = config.window_border
         if type(border) == "string" then
-            return border == "none" and minimap_height or minimap_height - 2
+            return (border == "none" and minimap_height) or (border == "shadow" and minimap_height - 1) or minimap_height - 2
         else
             local h = minimap_height
             if border[2] ~= "" then

--- a/lua/neominimap/window.lua
+++ b/lua/neominimap/window.lua
@@ -170,13 +170,24 @@ local get_window_config = function(winid)
         local border = config.window_border
         if type(border) == "string" then
             return (border == "none" and minimap_height) or (border == "shadow" and minimap_height - 1) or minimap_height - 2
-        else
-            local h = minimap_height
+        end
+        local h = minimap_height
+        if #border == 8 then
             if border[2] ~= "" then
                 h = h - 1
             end
             if border[6] ~= "" then
                 h = h - 1
+            end
+            return h
+        elseif #border == 4 or #border == 2 then
+            if border[2] ~= "" then
+                h = h - 2
+            end
+            return h
+        elseif #border == 1 then
+            if border[1] ~= "" then
+                h = h - 2
             end
             return h
         end

--- a/lua/neominimap/window.lua
+++ b/lua/neominimap/window.lua
@@ -168,25 +168,29 @@ local get_window_config = function(winid)
 
     local height = (function()
         local border = config.window_border
-        if type(border) == "string" then
-            return (border == "none" and minimap_height) or (border == "shadow" and minimap_height - 1) or minimap_height - 2
-        end
         local h = minimap_height
+        if type(border) == "string" then
+            return (border == "none" and h) or (border == "shadow" and h - 1) or h - 2
+        end
+        local function char(n)
+            local b = border[n]
+            return type(b) == "string" and b or b[1]
+        end
         if #border == 8 then
-            if border[2] ~= "" then
+            if char(2) ~= "" then
                 h = h - 1
             end
-            if border[6] ~= "" then
+            if char(6) ~= "" then
                 h = h - 1
             end
             return h
         elseif #border == 4 or #border == 2 then
-            if border[2] ~= "" then
+            if char(2) ~= "" then
                 h = h - 2
             end
             return h
         elseif #border == 1 then
-            if border[1] ~= "" then
+            if char(1) ~= "" then
                 h = h - 2
             end
             return h


### PR DESCRIPTION
## 1. deal with short windows

This PR fixes errors that occur when the target windows are too short to draw the minimap window with borders. For example, the height of the window is `2` and `window_border` is the default value: `"single"`, it shows an error below. 1198041 fixes this.

```
Error executing vim.schedule lua callback: .../share/nvim/lazy/neominimap.nvim/lua/neominimap/util.lua:12: 'height' key must be a positive Integer
stack traceback:
        [C]: in function 'f'
        .../share/nvim/lazy/neominimap.nvim/lua/neominimap/util.lua:12: in function <.../share/nvim/lazy/neominimap.nvim/lua/neominimap/util.lua:9>
        ...hare/nvim/lazy/neominimap.nvim/lua/neominimap/window.lua:217: in function 'create_minimap_window'
        ...hare/nvim/lazy/neominimap.nvim/lua/neominimap/window.lua:387: in function 'refresh_minimap_window'
        ...hare/nvim/lazy/neominimap.nvim/lua/neominimap/window.lua:433: in function 'refresh_all_minimap_windows'
        ...m/lazy/neominimap.nvim/lua/neominimap/command/global.lua:19: in function <...m/lazy/neominimap.nvim/lua/neominimap/command/global.lua:16>
```

## 2. deal with rare border formats

Formats `nvim_open_win` accepts as `border` option are below.

1. `string`: `"single"`, `"shadow"` and so on.
2. `string[]`: a table of characters
3. `[string, string][]`: a table of tuples containing a character and a highlight group

### 2.1. `string[]`: a table of characters

This takes `8`, `4`, `2` and `1` character(s).

```lua
border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" }
border = { "+", "─", "+", "│" }
border = { "+", "─" }
border = { "x" }
```

### 2.2. `[string, string][]`: a table of tuples containing a character and a highlight group

And each character may be a tuple.

```lua
-- This draw "x" with CurSearch highlight group.
border = { { "x", "CurSearch" } }
```
