### PR TITLE
fix: do not show eol characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The default `winopt` is:
     winblend = 0,
     cursorline = true,
     spell = false,
+    list = false,
 }
 ```
 

--- a/lua/neominimap/window.lua
+++ b/lua/neominimap/window.lua
@@ -252,6 +252,7 @@ M.create_minimap_window = function(winid)
         winblend = 0,
         cursorline = true,
         spell = false,
+        list = false,
     }
 
     local user_opt = type(config.winopt) == "function" and config.winopt(winid) or config.winopt


### PR DESCRIPTION
It shows `'listchars'` characters in neominimap when you `set list` in `init.lua`. This fixes it.

<img width="414" alt="スクリーンショット 2024-08-17 午前10 38 22" src="https://github.com/user-attachments/assets/72cebc70-9482-4bba-82bf-4b27114af8f6">

Example config below:

```lua
local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
if not (vim.uv or vim.loop).fs_stat(lazypath) then
  vim.fn.system {
    "git",
    "clone",
    "--filter=blob:none",
    "https://github.com/folke/lazy.nvim.git",
    "--branch=stable", -- latest stable release
    lazypath,
  }
end
vim.opt.rtp:prepend(lazypath)

require("lazy").setup {
  { "nvim-treesitter/nvim-treesitter", build = ":TSInstallSync lua" },
  {
    "Isrothy/neominimap.nvim",
    init = function()
      vim.opt.wrap = false       -- Recommended
      vim.opt.sidescrolloff = 36 -- It"s recommended to set a large value
      vim.g.neominimap = {
        auto_enable = true,
        git = { enabled = false },
      }
      vim.opt.list = true
      vim.opt.listchars = { eol = "⏎", extends = "‥", }
      vim.api.nvim_set_hl(0, "NonText", { fg = "NvimLightRed" })
    end,
  },
}
```
