### PR TITLE
fix: make eob character unseen in neominimap

### DIFF
--- a/lua/neominimap/window.lua
+++ b/lua/neominimap/window.lua
@@ -253,6 +253,7 @@ M.create_minimap_window = function(winid)
         cursorline = true,
         spell = false,
         list = false,
+        fillchars = "eob: ",
     }
 
     local user_opt = type(config.winopt) == "function" and config.winopt(winid) or config.winopt


### PR DESCRIPTION
This fix makes redundant eob characters (default: `~`) unseen.

| before                                                                                                                                                  | after                                                                                                                                                   |
|---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="370" alt="スクリーンショット 2024-08-19 午後4 44 55" src="https://github.com/user-attachments/assets/2413476e-b882-4656-a53c-ffbbd6d2088c"> | <img width="370" alt="スクリーンショット 2024-08-19 午後4 45 03" src="https://github.com/user-attachments/assets/41234833-fc0f-4f4e-9f16-3f515d0de796"> |

<details><summary>example config</summary>

```lua
local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
if not (vim.uv or vim.loop).fs_stat(lazypath) then
  vim.fn.system {
    "git",
    "clone",
    "--filter=blob:none",
    "https://github.com/folke/lazy.nvim.git",
    "--branch=stable", -- latest stable release
    lazypath,
  }
end
vim.opt.rtp:prepend(lazypath)

require("lazy").setup {
  { "nvim-treesitter/nvim-treesitter", build = ":TSInstall lua" },
  {
    "Isrothy/neominimap.nvim",
    dev = true,
    init = function()
      vim.opt.wrap = false       -- Recommended
      vim.opt.sidescrolloff = 36 -- It"s recommended to set a large value
      vim.g.neominimap = {
        auto_enable = true,
        git = { enabled = false },
      }
      vim.api.nvim_set_hl(0, "EndOfBuffer", { fg = "NvimLightRed" })
    end,
  },
}
```
</details>
