### PR TITLE
fix: check if source window is valid

### DIFF
--- a/lua/neominimap/buffer/internal.lua
+++ b/lua/neominimap/buffer/internal.lua
@@ -83,7 +83,7 @@ M.internal_render = function(bufnr)
     local mbufnr_ = buffer_map.get_minimap_bufnr(bufnr)
     if not mbufnr_ or not api.nvim_buf_is_valid(mbufnr_) then
         logger.log(
-            string.format("Minimap buffer %d is not valid. Skipping generation of minimap.", mbufnr_),
+            "Minimap buffer is not valid. Skipping generation of minimap.",
             vim.log.levels.WARN
         )
         return

--- a/lua/neominimap/window/split/internal.lua
+++ b/lua/neominimap/window/split/internal.lua
@@ -224,6 +224,10 @@ M.refresh_source_in_current_tab = function()
             return winid
         end
     end)()
+    if swinid == nil or not api.nvim_win_is_valid(swinid) then
+        logger.log("No source window found", vim.log.levels.TRACE)
+        return
+    end
     window_map.set_source_winid(tabid, swinid)
     logger.log(string.format("Source window %d set", swinid), vim.log.levels.TRACE)
 


### PR DESCRIPTION
A check was missing for the split layout.
This causes issues when for example opening a telescope window.