### PR TITLE
feat: Close neovim if neominimap is the last window on WinClosed event

### DIFF
--- a/lua/neominimap/window/split/autocmds.lua
+++ b/lua/neominimap/window/split/autocmds.lua
@@ -37,6 +37,13 @@ M.create_autocmds = function()
                 string.format("WinClosed event triggered for window %d.", tonumber(args.match)),
                 vim.log.levels.TRACE
             )
+            local enabled = require("neominimap.variables").g.enabled
+            local mbufnr = require("neominimap.buffer").get_minimap_bufnr(args.buf)
+            -- 2 because window is still listed in its own WinClosed event
+            if mbufnr ~= nil and #vim.api.nvim_list_wins() == 2 and enabled then
+                logger.log("Quitting vim", vim.log.levels.TRACE)
+                vim.cmd("quitall")
+            end
             vim.schedule(function()
                 logger.log("Refreshing minimap window", vim.log.levels.TRACE)
                 require("neominimap.window.split.internal").refresh_source_in_current_tab()


### PR DESCRIPTION
When using the split layout, neovim doesn't fully close until you also close the neominimap window.
This PR fixes that.

This might not be wanted behavior for you, so feel free to just close this or suggest improvements.