### PR TITLE
fix: minimap jump to the end of buffer on source buffer change

### DIFF
--- a/lua/neominimap/buffer/internal.lua
+++ b/lua/neominimap/buffer/internal.lua
@@ -80,6 +80,7 @@ end
 M.internal_render_co = function(bufnr)
     local logger = require("neominimap.logger")
     local co_api = require("neominimap.cooperative.api")
+    local util = require("neominimap.window.util")
     logger.log(string.format("Generating minimap for buffer %d", bufnr), vim.log.levels.TRACE)
     local buffer_map = require("neominimap.buffer.buffer_map")
     local mbufnr_ = buffer_map.get_minimap_bufnr(bufnr)
@@ -87,6 +88,8 @@ M.internal_render_co = function(bufnr)
         logger.log("Minimap buffer is not valid. Skipping generation of minimap.", vim.log.levels.WARN)
         return
     end
+    local swinid = vim.fn.bufwinid(bufnr)
+    local mwinid = vim.fn.bufwinid(mbufnr_)
 
     logger.log(string.format("Getting lines for buffer %d", bufnr), vim.log.levels.TRACE)
     local lines = co_api.buf_get_lines_co(bufnr, 0, -1)
@@ -112,7 +115,9 @@ M.internal_render_co = function(bufnr)
     vim.bo[mbufnr_].modifiable = true
 
     logger.log(string.format("Setting lines for buffer %d", mbufnr_), vim.log.levels.TRACE)
+    util.sync_to_source(swinid, mwinid)
     co_api.buf_set_lines_co(mbufnr_, 0, -1, minimap)
+    util.sync_to_source(swinid, mwinid)
     logger.log(string.format("Minimap for buffer %d generated successfully", bufnr), vim.log.levels.TRACE)
 
     vim.bo[mbufnr_].modifiable = false

--- a/lua/neominimap/cooperative/api.lua
+++ b/lua/neominimap/cooperative/api.lua
@@ -32,10 +32,6 @@ end
 ---@param replacement string[] The lines to set
 ---@param chunk_size integer? The number of lines to set before yielding
 M.buf_set_lines_co = function(bufnr, start, stop, replacement, chunk_size)
-    local sbufnr = require("neominimap.buffer.buffer_map").get_source_bufnr(bufnr)
-    local swinid = vim.fn.bufwinid(sbufnr)
-    local mwinid = vim.fn.bufwinid(bufnr)
-
     chunk_size = chunk_size or 200
     local total_lines = #replacement
     local chunks = math.ceil(total_lines / chunk_size)
@@ -49,11 +45,6 @@ M.buf_set_lines_co = function(bufnr, start, stop, replacement, chunk_size)
         -- Set the chunk of lines
         vim.api.nvim_buf_set_lines(bufnr, start, start, false, lines)
         start = start + #lines -- Update start for the next chunk
-
-        -- This hack sets the cursor right away to avoid visual "jumps" to the end of the minimap buffer and back
-        if start >= i then
-            require("neominimap.window.util").sync_to_source(swinid, mwinid)
-        end
 
         coroutine.yield() -- Yield after setting a chunk
     end


### PR DESCRIPTION
Fixes an issue show below

https://github.com/user-attachments/assets/9eab5170-1cdb-474b-a9c3-9dc84533d6f3

My solution is not optimal since it sets the cursor multiple times but it works fine. Much better solution would be to create a new hidden minimap buffer, fill it up with content and after all of the async is done swap the current minimap with the new one. This will also fix highlighting flickering like in the video.
However, i think it's best to be implemented together with #187. 