### PR TITLE
Minor addition to the split mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,13 @@ vim.g.neominimap ={
         -- Always fix the width of the split window
         fix_width = false, ---@type boolean
 
-        ---@alias Neominimap.Config.SplitDirection "left" | "right"
+        -- split mode:
+        -- left is an alias for topleft   - leftmost vertical split, full height
+        -- right is an alias for botright - rightmost vertical split, full height
+        -- aboveleft -  left split in current window
+        -- rightbelow - right split in current window
+        ---@alias Neominimap.Config.SplitDirection "left" | "right" | 
+        ---       "topleft" | "botright" | "aboveleft" | "rightbelow"
         direction = "right", ---@type Neominimap.Config.SplitDirection
 
         ---Automatically close the split window when it is the last window

--- a/lua/neominimap/config/internal.lua
+++ b/lua/neominimap/config/internal.lua
@@ -69,7 +69,7 @@ local M = {
         -- Always fix the width of the split window
         fix_width = false, ---@type boolean
 
-        ---@alias Neominimap.Config.SplitDirection "left" | "right"
+        ---@alias Neominimap.Config.SplitDirection "left" | "right" | "topleft" | "botright" | "aboveleft" | "rightbelow"
         direction = "right", ---@type Neominimap.Config.SplitDirection
 
         ---Automatically close the split window when it is the last window

--- a/lua/neominimap/window/split/internal.lua
+++ b/lua/neominimap/window/split/internal.lua
@@ -123,10 +123,12 @@ M.create_minimap_window_in_current_tab = function()
 
     ---@type table<Neominimap.Config.SplitDirection, string>
     local dir_tbl = {
-        ["right"] = "rightbelow",
+        ["right"] = "botright",
+        ["rightbelow"] = "rightbelow",
         ["left"] = "topleft",
+        ["aboveleft"] = "aboveleft"
     }
-    vim.cmd(string.format("noau vertical %s %dsplit", dir_tbl[config.split.direction], config:get_minimap_width()))
+    vim.cmd(string.format("noau vertical %s %dsplit", dir_tbl[config.split.direction] or "botright", config:get_minimap_width()))
     local mwinid = vim.api.nvim_get_current_win()
     util.noautocmd(api.nvim_set_current_win)(winid)
 

--- a/lua/neominimap/window/split/internal.lua
+++ b/lua/neominimap/window/split/internal.lua
@@ -123,12 +123,12 @@ M.create_minimap_window_in_current_tab = function()
 
     ---@type table<Neominimap.Config.SplitDirection, string>
     local dir_tbl = {
-        ["left"]        = "topleft",
-        ["right"]       = "botright",
-        ["topleft"]     = "topleft",
-        ["botright"]    = "botright",
-        ["aboveleft"]   = "aboveleft",
-        ["rightbelow"]  = "rightbelow"
+        ["left"] = "topleft",
+        ["right"] = "botright",
+        ["topleft"] = "topleft",
+        ["botright"] = "botright",
+        ["aboveleft"] = "aboveleft",
+        ["rightbelow"] = "rightbelow",
     }
     vim.cmd(
         string.format(

--- a/lua/neominimap/window/split/internal.lua
+++ b/lua/neominimap/window/split/internal.lua
@@ -123,10 +123,12 @@ M.create_minimap_window_in_current_tab = function()
 
     ---@type table<Neominimap.Config.SplitDirection, string>
     local dir_tbl = {
-        ["right"] = "botright",
-        ["rightbelow"] = "rightbelow",
-        ["left"] = "topleft",
-        ["aboveleft"] = "aboveleft"
+        ["left"]        = "topleft",
+        ["right"]       = "botright",
+        ["topleft"]     = "topleft",
+        ["botright"]    = "botright",
+        ["aboveleft"]   = "aboveleft",
+        ["rightbelow"]  = "rightbelow"
     }
     vim.cmd(string.format("noau vertical %s %dsplit", dir_tbl[config.split.direction] or "botright", config:get_minimap_width()))
     local mwinid = vim.api.nvim_get_current_win()

--- a/lua/neominimap/window/split/internal.lua
+++ b/lua/neominimap/window/split/internal.lua
@@ -123,7 +123,7 @@ M.create_minimap_window_in_current_tab = function()
 
     ---@type table<Neominimap.Config.SplitDirection, string>
     local dir_tbl = {
-        ["right"] = "botright",
+        ["right"] = "rightbelow",
         ["left"] = "topleft",
     }
     vim.cmd(string.format("noau vertical %s %dsplit", dir_tbl[config.split.direction], config:get_minimap_width()))

--- a/lua/neominimap/window/split/internal.lua
+++ b/lua/neominimap/window/split/internal.lua
@@ -130,7 +130,13 @@ M.create_minimap_window_in_current_tab = function()
         ["aboveleft"]   = "aboveleft",
         ["rightbelow"]  = "rightbelow"
     }
-    vim.cmd(string.format("noau vertical %s %dsplit", dir_tbl[config.split.direction] or "botright", config:get_minimap_width()))
+    vim.cmd(
+        string.format(
+            "noau vertical %s %dsplit",
+            dir_tbl[config.split.direction] or "botright",
+            config:get_minimap_width()
+        )
+    )
     local mwinid = vim.api.nvim_get_current_win()
     util.noautocmd(api.nvim_set_current_win)(winid)
 


### PR DESCRIPTION
Hi, great plugin, this is so far the best minimap I've found for Neovim.

I have a small proposal to add two more split modes for `split.direction`: `rightbelow` and `aboveleft`. They differ from the defaults in that they will not split the editor "full height" but only the height of the current window. I usually have a horizontal split with a term below my main code window and `rightbelow` would split the minimap from the current window only and leave the terminal split alone.

The options should not clash with the currently available settings `left` and `right` so existing configurations should not be affected.

There is also a minor safeguard to avoid a `nil` reference when `split.direction` contains an invalid value.