### PR TITLE
fix: neominimap boundary line issue

### DIFF
--- a/lua/neominimap/window/util.lua
+++ b/lua/neominimap/window/util.lua
@@ -85,13 +85,13 @@ local function set_current_line_by_percentage(winid, row)
     local win_h = M.win_get_true_height(winid)
     local bufnr = api.nvim_win_get_buf(winid)
     local line_cnt = api.nvim_buf_line_count(bufnr)
-    local topline = math.floor(row - (row * win_h) / line_cnt)
+    local topline = math.floor(row - (row * win_h) / line_cnt) + 1
     row = math.max(1, math.min(row, line_cnt))
     topline = math.max(1, math.min(topline, line_cnt))
     return function()
         local view = vim.fn.winsaveview()
         view.topline = topline
-        view.lnum = row - 1
+        view.lnum = row
         vim.fn.winrestview(view)
     end
 end


### PR DESCRIPTION
The reason I used `view.lnum = row - 1` was because during testing, I found that the highlight line would disappear when the file was scrolled to the last line. I therefore thought that view.lnum was 0-indexed.

However, in actual use, I found that the minimap was always one line shorter than the preview, so it should be `topline + 1`.

![line_1](https://github.com/user-attachments/assets/6e5b8fc4-b532-43c9-bafc-32eb0c41a851)

