### PR TITLE
fix: "search" Icon Row Count Increases When "search" Coordinate is Multiple of 4

### DIFF
--- a/lua/neominimap/map/handlers/builtins/search.lua
+++ b/lua/neominimap/map/handlers/builtins/search.lua
@@ -75,6 +75,7 @@ local get_matches = function(bufnr)
         for lnum, line in ipairs(lines) do
             local ok, col = pcall(fn.match, line, pattern, 0)
             if ok and col ~= -1 then
+                lnum = lnum + (lnum % 4 == 0 and 0 or 1)
                 matches[#matches + 1] = lnum
             end
         end
@@ -97,8 +98,8 @@ M.get_annotations = function(bufnr)
     return vim.tbl_map(function(lnum)
         ---@type Neominimap.Map.Handler.Annotation[]
         return {
-            lnum = lnum + 1,
-            end_lnum = lnum + 1,
+            lnum = lnum,
+            end_lnum = lnum,
             priority = config.search.priority,
             id = 1,
             icon = config.search.icon,


### PR DESCRIPTION
When the "search" coordinate is a multiple of 4, the "search" icon has one extra row.
This happens when current_line_position is "center" or "percent".
So, the issue likely lies with the "search" coordinate's row.
I’m unsure of the exact bug cause; I just observed the numerical pattern across all rows.

<img width="619" height="360" alt="image" src="https://github.com/user-attachments/assets/40e35e31-18e3-436f-8b3d-8d709c961c49" />

<img width="619" height="360" alt="image" src="https://github.com/user-attachments/assets/1085cc9c-0a9c-43d3-9486-1215cf91639b" />

<img width="619" height="360" alt="image" src="https://github.com/user-attachments/assets/9dd7cef8-9c20-48f1-af26-299fb96cfacd" />

