### PR TITLE
fix: disable minimap for image files and fix border nil error

### DIFF
--- a/lua/neominimap/buffer/internal.lua
+++ b/lua/neominimap/buffer/internal.lua
@@ -35,6 +35,13 @@ M.should_generate_minimap = function(bufnr)
     local var = require("neominimap.variables")
     local filetype = vim.bo[bufnr].filetype
     local buftype = vim.bo[bufnr].buftype
+    local bufname = vim.api.nvim_buf_get_name(bufnr)
+    local ext = vim.fn.fnamemodify(bufname, ":e"):lower()
+    local img_exts = { "png", "jpg", "jpeg", "gif", "webp", "avif", "svg", "ico", "bmp" }
+    if vim.tbl_contains(img_exts, ext) then
+        logger.log.trace("Buffer %d should not generate minimap due to image extension %s", bufnr, ext)
+        return false
+    end
     if not var.g.enabled then
         logger.log.trace("Neominimap is disabled. Skipping generation of minimap for buffer %d", bufnr)
         return false

--- a/lua/neominimap/window/float/internal.lua
+++ b/lua/neominimap/window/float/internal.lua
@@ -25,7 +25,7 @@ local get_minimap_height = function(winid)
         end
     else
         local char = function(n)
-            local b = border[n]
+            local b = border[n] or ""
             return type(b) == "string" and b or b[1]
         end
         local minimap_height = minimap_window_height


### PR DESCRIPTION
1. Disable minimap generation for common image filetypes (png, jpg, etc.) in buffer filter.

2. Fix a nil index error in float window internal rendering when `window_border` is a sparse table.