### PR TITLE
fix(config): border cannot be empty table

### DIFF
--- a/lua/neominimap/config/internal.lua
+++ b/lua/neominimap/config/internal.lua
@@ -110,7 +110,7 @@ local M = {
         --- Border style of the floating window.
         --- Accepts all usual border style options (e.g., "single", "double")
         --- @type string | string[] | [string, string][]
-        window_border = vim.fn.has("nvim-0.11") == 1 and vim.opt.winborder:get() or "single",
+        window_border = vim.fn.has("nvim-0.11") == 1 and vim.o.winborder or "single",
 
         -- When true, the floating window will be recreated when you close it.
         -- When false, the minimap will be disabled for the current window when you close the minimap window.


### PR DESCRIPTION
when winborder is not set, this give `{}`
which is rejected by nvim_open_win
